### PR TITLE
Add GitHub Pages redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,6 @@
 
 This repository contains a personal portfolio site. Configure Medium and resume/LinkedIn in `portfolio/config.json` and run the fetch script to populate blog posts.
 
+The root `index.html` simply redirects to the `portfolio/` directory so the site can be served directly from GitHub Pages.
+
 - Development: see `portfolio/README.md`.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Portfolio</title>
+    <meta http-equiv="refresh" content="0; url=portfolio/" />
+    <link rel="canonical" href="portfolio/" />
+  </head>
+  <body>
+    <p>Redirecting to <a href="portfolio/">portfolio</a>...</p>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add root index.html that forwards to the `portfolio` directory for GitHub Pages
- document GitHub Pages redirect in README

## Testing
- `npx --yes htmlhint index.html portfolio/index.html` *(fails: 403 Forbidden - GET https://registry.npmjs.org/htmlhint)*

------
https://chatgpt.com/codex/tasks/task_e_6897ddf900488325813e52a65c9d6dc8